### PR TITLE
Update dependencies and update to reflect new PHP Parser changes.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         php:
-          - 7.2
-          - 7.3
           - 7.4
           - 8.0
           - 8.1
+          - 8.2
+          - 8.3
       fail-fast: false
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         "issues": "https://github.com/php-gettext/PHP-Scanner/issues"
     },
     "require": {
-        "php": ">=7.2",
-        "nikic/php-parser": "^4.2",
+        "php": ">=7.4",
+        "nikic/php-parser": "^5",
         "gettext/gettext": "^5.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^11",
         "squizlabs/php_codesniffer": "^3.0",
-        "oscarotero/php-cs-fixer-config": "^1.0",
-        "friendsofphp/php-cs-fixer": "^2.15"
+        "oscarotero/php-cs-fixer-config": "^2",
+        "friendsofphp/php-cs-fixer": "^3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "gettext/gettext": "^5.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11",
+        "phpunit/phpunit": "^9",
         "squizlabs/php_codesniffer": "^3.0",
         "oscarotero/php-cs-fixer-config": "^2",
         "friendsofphp/php-cs-fixer": "^3"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,13 @@
-<phpunit bootstrap="./vendor/autoload.php">
-	<testsuites>
-		<testsuite name="All tests">
-			<directory>./tests/</directory>
-		</testsuite>
-	</testsuites>
-	<filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="All tests">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="All tests">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
-  <source>
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </source>
 </phpunit>

--- a/src/PhpFunctionsScanner.php
+++ b/src/PhpFunctionsScanner.php
@@ -10,13 +10,13 @@ use PhpParser\ParserFactory;
 
 class PhpFunctionsScanner implements FunctionsScannerInterface
 {
-    protected $parser;
-    protected $validFunctions;
+    protected Parser $parser;
+    protected ?array $validFunctions;
 
     public function __construct(array $validFunctions = null, Parser $parser = null)
     {
         $this->validFunctions = $validFunctions;
-        $this->parser = $parser ?: (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $this->parser = $parser ?: (new ParserFactory())->createForNewestSupportedVersion();
     }
 
     public function scan(string $code, string $filename): array
@@ -35,7 +35,7 @@ class PhpFunctionsScanner implements FunctionsScannerInterface
         return $visitor->getFunctions();
     }
 
-    protected function createNodeVisitor(string $filename): NodeVisitor
+    protected function createNodeVisitor(string $filename): PhpNodeVisitor
     {
         return new PhpNodeVisitor($filename, $this->validFunctions);
     }

--- a/src/PhpFunctionsScanner.php
+++ b/src/PhpFunctionsScanner.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Gettext\Scanner;
 
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
 
@@ -27,9 +26,9 @@ class PhpFunctionsScanner implements FunctionsScannerInterface
             return [];
         }
 
-        $traverser = new NodeTraverser();
         $visitor = $this->createNodeVisitor($filename);
-        $traverser->addVisitor($visitor);
+
+        $traverser = new NodeTraverser($visitor);
         $traverser->traverse($ast);
 
         return $visitor->getFunctions();

--- a/src/PhpNodeVisitor.php
+++ b/src/PhpNodeVisitor.php
@@ -7,16 +7,19 @@ use PhpParser\Comment;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\NodeVisitor;
 
 class PhpNodeVisitor implements NodeVisitor
 {
-    protected $validFunctions;
-    protected $filename;
-    protected $functions = [];
-    protected $bufferComments;
+    protected ?array $validFunctions;
+    protected string $filename;
+    protected array $functions = [];
+
+    /** @var Comment[] */
+    protected array $bufferComments = [];
 
     public function __construct(string $filename, array $validFunctions = null)
     {
@@ -40,15 +43,17 @@ class PhpNodeVisitor implements NodeVisitor
                 if ($name && ($this->validFunctions === null || in_array($name, $this->validFunctions))) {
                     $this->functions[] = $this->createFunction($node);
                 } elseif ($node->getComments()) {
-                    $this->bufferComments = $node;
+                    $this->bufferComments[] = $node;
                 }
-                return null;
+                break;
+
+            case 'Stmt_Expression':
             case 'Stmt_Echo':
             case 'Stmt_Return':
             case 'Expr_Print':
             case 'Expr_Assign':
-                $this->bufferComments = $node;
-                return null;
+                $this->bufferComments[] = $node;
+                break;
         }
 
         return null;
@@ -85,13 +90,17 @@ class PhpNodeVisitor implements NodeVisitor
             $function->addComment(static::getComment($comment));
         }
 
-        if ($this->bufferComments && $this->bufferComments->getStartLine() === $node->getStartLine()) {
-            foreach ($this->bufferComments->getComments() as $comment) {
-                $function->addComment(static::getComment($comment));
+        if ($this->bufferComments) {
+            foreach ($this->bufferComments as $bufferComment) {
+                if ($bufferComment->getStartLine() === $node->getStartLine()) {
+                    foreach ($bufferComment->getComments() as $comment) {
+                        $function->addComment(static::getComment($comment));
+                    }
+                }
             }
         }
 
-        $this->bufferComments = null;
+        $this->bufferComments = [];
 
         foreach ($node->args as $argument) {
             $value = $argument->value;

--- a/src/PhpNodeVisitor.php
+++ b/src/PhpNodeVisitor.php
@@ -149,8 +149,8 @@ class PhpNodeVisitor implements NodeVisitor
 
         switch ($type) {
             case 'Scalar_String':
-            case 'Scalar_LNumber':
-            case 'Scalar_DNumber':
+            case 'Scalar_Int':
+            case 'Scalar_Float':
                 return $value->value;
             case 'Expr_BinaryOp_Concat':
                 $values = [];

--- a/src/PhpScanner.php
+++ b/src/PhpScanner.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace Gettext\Scanner;
 
 use Gettext\Translation;
-use Gettext\Translations;
 
 /**
  * Class to scan PHP files and get gettext translations

--- a/tests/PhpFunctionsScannerTest.php
+++ b/tests/PhpFunctionsScannerTest.php
@@ -29,7 +29,7 @@ class PhpFunctionsScannerTest extends TestCase
         $function = array_shift($functions);
         $this->assertSame('fn1', $function->getName());
         $this->assertSame(3, $function->countArguments());
-        $this->assertSame(['arg1', 'arg2', 3], $function->getArguments());
+        $this->assertSame(['arg1', 'arg2', null], $function->getArguments());
         $this->assertSame(4, $function->getLine());
         $this->assertSame(4, $function->getLastLine());
         $this->assertSame($file, $function->getFilename());
@@ -71,7 +71,7 @@ class PhpFunctionsScannerTest extends TestCase
         $function = array_shift($functions);
         $this->assertSame('fn5', $function->getName());
         $this->assertSame(2, $function->countArguments());
-        $this->assertSame([6, 7.5], $function->getArguments());
+        $this->assertSame([null, null], $function->getArguments());
         $this->assertSame(6, $function->getLine());
         $this->assertSame(6, $function->getLastLine());
         $this->assertSame($file, $function->getFilename());
@@ -187,41 +187,5 @@ class PhpFunctionsScannerTest extends TestCase
         $this->assertSame(34, $function->getLastLine());
         $this->assertSame($file, $function->getFilename());
         $this->assertCount(0, $function->getComments());
-    }
-
-    public function _testPhpFunctionsScannerWithDisabledComments()
-    {
-        $scanner = new PhpFunctionsScanner();
-        $scanner->includeComments(false);
-        $file = __DIR__.'/assets/functions.php';
-        $code = file_get_contents($file);
-        $functions = $scanner->scan($code, $file);
-
-        $this->assertCount(11, $functions);
-
-        foreach ($functions as $function) {
-            $this->assertCount(0, $function->getComments());
-        }
-    }
-
-    public function _testPhpFunctionsScannerWithPrefixedComments()
-    {
-        $scanner = new PhpFunctionsScanner();
-        $scanner->includeComments(['ALLOW:']);
-        $file = __DIR__.'/assets/functions.php';
-        $code = file_get_contents($file);
-        $functions = $scanner->scan($code, $file);
-
-        $this->assertCount(11, $functions);
-
-        //fn12
-        $function = $functions[10];
-        $this->assertCount(1, $function->getComments());
-
-        $comments = $function->getComments();
-        $comment = $comments[0];
-        $this->assertSame(23, $comment->getLine());
-        $this->assertSame(23, $comment->getLastLine());
-        $this->assertSame('ALLOW: Related comment 3', $comment->getComment());
     }
 }

--- a/tests/PhpFunctionsScannerTest.php
+++ b/tests/PhpFunctionsScannerTest.php
@@ -29,7 +29,7 @@ class PhpFunctionsScannerTest extends TestCase
         $function = array_shift($functions);
         $this->assertSame('fn1', $function->getName());
         $this->assertSame(3, $function->countArguments());
-        $this->assertSame(['arg1', 'arg2', null], $function->getArguments());
+        $this->assertSame(['arg1', 'arg2', 3], $function->getArguments());
         $this->assertSame(4, $function->getLine());
         $this->assertSame(4, $function->getLastLine());
         $this->assertSame($file, $function->getFilename());
@@ -71,7 +71,7 @@ class PhpFunctionsScannerTest extends TestCase
         $function = array_shift($functions);
         $this->assertSame('fn5', $function->getName());
         $this->assertSame(2, $function->countArguments());
-        $this->assertSame([null, null], $function->getArguments());
+        $this->assertSame([6, 7.5], $function->getArguments());
         $this->assertSame(6, $function->getLine());
         $this->assertSame(6, $function->getLastLine());
         $this->assertSame($file, $function->getFilename());

--- a/tests/PhpScannerTest.php
+++ b/tests/PhpScannerTest.php
@@ -23,7 +23,12 @@ class PhpScannerTest extends TestCase
 
         $scanner->scanFile($file);
 
-        list('domain1' => $domain1, 'domain2' => $domain2, 'domain3' => $domain3) = $scanner->getTranslations();
+        /**
+         * @var Translations $domain1
+         * @var Translations $domain2
+         * @var Translations $domain3
+         */
+        ['domain1' => $domain1, 'domain2' => $domain2, 'domain3' => $domain3] = $scanner->getTranslations();
 
         $this->assertCount(6, $domain1);
         $this->assertCount(4, $domain2);


### PR DESCRIPTION
This PR changes the following:
 - Updates `composer.json` to depend on `nikic/php-parser` version 5.x instead of 4.x
 - Bump the minimum PHP version from 7.2 to 7.4 (php-parser itself only supports 7.4 and up)
 - Bump the versions of the testing dependencies
 - Update factory instantiation to reflect php-parser's new syntax
 - Slightly update how comments are parsed to handle changes in the parser